### PR TITLE
Uninstall package if disabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ntp_pkg_state: 'present'
+ntp_pkg_state: "{{ 'present' if ntp_service_enabled else 'absent' }}"
 ntp_service_state: 'started'
 ntp_service_enabled: 'yes'
 ntp_blacklist_enabled: "{{ ntp_service_enabled }}"


### PR DESCRIPTION
This allows you to run the role with ntp_stated_enabled = False on distributions without the ntp package e.g CentOS8