### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: Add the OS specific variables
-  include_vars: '{{ ansible_os_family }}.yml'
+  include_vars: '{{ ansible_facts.os_family }}.yml'
   tags: [ 'configuration', 'package', 'service', 'ntp' ]
 
 - name: Install the required packages in Redhat derivatives
   yum: name=ntp state={{ ntp_pkg_state }}
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
   tags: [ 'package', 'ntp' ]
 
 - name: Install the required packages in Debian derivatives
   apt: name=ntp state={{ ntp_pkg_state }} update_cache=yes cache_valid_time=86400
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
   tags: [ 'package', 'ntp' ]
 
 - name: Copy the ntp.conf template file


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars